### PR TITLE
SSM Session Manage & EKS worker Node Instance Log Shipping 0.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 **/.terraform/*
 *.tfstate
 *.tfstate.backup
+*.plan
+.terraform.tfstate.lock.info
 
 # Terragrunt Cache
 .terragrunt-cache/

--- a/README.md
+++ b/README.md
@@ -1,26 +1,70 @@
-# Terraform EKS Module
-This module provisions an EKS control plane and a Worker nodes ASG. Adds the `aws-auth` ConfigMap from the Terraform Kubernetes Provider, allowing worker nodes to join the control plane without the need for a separate `kubectl` command. Designed to share an existing and provisioned VPC.
+# Terraform AWS EKS Module
+This module provisions an EKS control plane and a Worker node ASG. Adds the `aws-auth` ConfigMap from the Terraform Kubernetes Provider, allowing worker nodes to automatically join the control plane without the need for a separate `kubectl` command. The module is dependent on a configured VPC.
 
-The cluster_config output can be used to provide the kubectl connection configuration parameters.
+It takes about ~10 mins for a control plane to converge.
+
+## Kubernetes Provider 1.11
+This module does not work with the Kubernetes provider version 1.11 and has been pinned to version 1.10. A change has been made that now impacts the current design.
+
+## AWS SSM Session Manager
+The EKS worker nodes are configure by default to support Session Manager connections. This provides shell access to an EKS worker node, without the need for a bastion host and a key rotation/management policy. Access to Session Manager can be managed by IAM roles & Policies and provides a full history of connected sessions. More information on how to start a session can be found here - https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-sessions-start.html
+
+## EKS Control Plane Logging
+EKs control plane logging is set to persist logs to the `/aws/eks/${var.cluster_name/cluster}` log group.
+
+## EKS Node Instance Logging
+EKS worker nodes now log ship the following instance logs to the CloudWatch log group `/aws/eks/${var.cluster_name}/node_logs`
+
+* `/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log` to the `cloudwatch-agent-{instance_id}` stream.
+
+* `/var/log/cloud-init-output.log` to the `cloud-init-output-{instance_id}` stream.
+
+* `/var/log/messages"` to the `syslog-{instance_id}` stream.
+
+The variable `cloudwatch_log_retention` controls how long logs are stored for all log groups.
+
+## Kube2Iam Support
+This module provides optional support for the `Kube2Iam` pattern. The setting will create the IAM roles and policies to allow the worker node role to assume the role requires for a specific Kubernetes service.
+
+All service roles must be prefixed with `k8s-` in order to assume the role.
+
+At this stage, this module does not apply the Kube2Iam manifest. This is currently out of scope for this module.
+
+More information on Kube2Iam can be found here - https://github.com/jtblin/kube2iam
+
+## Example
+An example has been provided at examples/default. This example can be used to understand how to implement this module.
+
+---
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2.19 |
+| kubernetes | 1.10 |
+| template | ~> 2.1.2 ~> 2.1.2 |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| cluster\_name | The EKS cluster name | string | n/a | yes |
-| k8s\_version | The K8s version to use on the cluster | string | n/a | yes |
-| maproles\_team\_role\_arn | The arn of the IAM role that maps to a Kubernetes role | string | n/a | yes |
-| vpc\_id | The vpc_id that the cluster will bind to | string | n/a | yes |
-| worker\_asg\_desired\_count | Desired number of nodes for worker asg | string | n/a | yes |
-| worker\_asg\_max\_size | Maximum number of nodes for worker asg | string | n/a | yes |
-| worker\_node\_instance\_type | Instance type used for EKS worker Nodes | string | n/a | yes |
-| eks\_master\_subnet\_ids | Subnet ids for the EKS Master Cluster | list | `<list>` | no |
-| eks\_vpc\_enable\_endpoint\_private\_access | Enable EKS cluster endpoint from within the VPC | string | `"true"` | no |
-| eks\_vpc\_enable\_endpoint\_public\_access | Enable EKS cluster endpoint from the internet | string | `"false"` | no |
-| eks\_worker\_subnet\_ids | Subnet ids for the EKS worker nodes | list | `<list>` | no |
-| maproles\_username | The user name of the product teams for the maprole config | string | `"kubectl-user-access"` | no |
-| supports\_kube2iam | A flag to control if an additional IAM policy to assume roles for Kube2Iam is added to worker node role | string | `"false"` | no |
-| worker\_asg\_min\_size | Minimum number of nodes for worker asg | string | `"1"` | no |
+|------|-------------|------|---------|:-----:|
+| cluster\_name | The EKS cluster name | `any` | n/a | yes |
+| k8s\_version | The K8s version to use on the cluster | `any` | n/a | yes |
+| maproles\_team\_role\_arn | The arn of the IAM role that maps to a Kubernetes role | `any` | n/a | yes |
+| vpc\_id | The vpc\_id that the cluster will bind to | `any` | n/a | yes |
+| worker\_asg\_desired\_count | Desired number of nodes for worker asg | `any` | n/a | yes |
+| worker\_asg\_max\_size | Maximum number of nodes for worker asg | `any` | n/a | yes |
+| worker\_node\_instance\_type | Instance type used for EKS worker Nodes | `any` | n/a | yes |
+| cloudwatch\_log\_retention | The retention period in days for all CloudWatch Log Group. Defaults to `7 days` | `number` | `7` | no |
+| eks\_master\_subnet\_ids | Subnet ids for the EKS Master Cluster | `list` | `[]` | no |
+| eks\_vpc\_enable\_endpoint\_private\_access | Enable EKS cluster endpoint from within the VPC | `bool` | `true` | no |
+| eks\_vpc\_enable\_endpoint\_public\_access | Enable EKS cluster endpoint from the internet | `bool` | `false` | no |
+| eks\_worker\_subnet\_ids | Subnet ids for the EKS worker nodes | `list` | `[]` | no |
+| maproles\_username | The user name of the product teams for the maprole config | `string` | `"kubectl-user-access"` | no |
+| ssh\_key\_name | The key pair to use for ssh connections | `string` | `""` | no |
+| supports\_kube2iam | A flag to control if an additional IAM policy to assume roles for Kube2Iam is added to worker node role | `bool` | `false` | no |
+| worker\_asg\_min\_size | Minimum number of nodes for worker asg | `number` | `1` | no |
 
 ## Outputs
 

--- a/aws.tf
+++ b/aws.tf
@@ -1,4 +1,0 @@
-provider "aws" {
-  version = "~> 2.19"
-}
-

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,5 +1,10 @@
 resource "aws_cloudwatch_log_group" "this" {
-  name              = "/aws/eks/${var.cluster_name}/cluster"
-  retention_in_days = 7
+  name              = local.cluster_log_group
+  retention_in_days = var.cloudwatch_log_retention
+}
+
+resource "aws_cloudwatch_log_group" "k8_worker_node" {
+  name              = local.worker_node_log_group
+  retention_in_days = var.cloudwatch_log_retention
 }
 

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -1,6 +1,10 @@
 module "example" {
   source = "../../"
 
+  providers {
+    aws = "aws"
+  }
+
   cluster_name                          = "eks-stage-example"
   k8s_version                           = 1.13
   vpc_id                                = aws_vpc.test_vpc.id
@@ -8,9 +12,16 @@ module "example" {
   eks_worker_subnet_ids                 = [aws_subnet.private1.id, aws_subnet.private2.id, aws_subnet.private3.id]
   eks_vpc_enable_endpoint_public_access = true
   worker_node_instance_type             = "t3.small"
-  worker_asg_desired_count              = 3
-  worker_asg_max_size                   = 3
+  worker_asg_desired_count              = 1
+  worker_asg_max_size                   = 1
 
   maproles_team_role_arn = ""
 }
 
+provider "aws" {
+  region = var.aws_region
+}
+
+variable "aws_region" {
+  default = "ap-southeast-2"
+}

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -1,8 +1,8 @@
 module "example" {
   source = "../../"
 
-  providers {
-    aws = "aws"
+  providers = {
+    aws = aws
   }
 
   cluster_name                          = "eks-stage-example"

--- a/examples/default/network.tf
+++ b/examples/default/network.tf
@@ -1,46 +1,113 @@
 # Build dependecies for the example.
 resource "aws_vpc" "test_vpc" {
   cidr_block = "10.0.0.0/16"
+
+  tags {
+    Name = "EKS Example VPC"
+  }
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 resource "aws_subnet" "private1" {
   cidr_block        = "10.0.2.0/24"
   vpc_id            = aws_vpc.test_vpc.id
   availability_zone = "ap-southeast-2a"
+
+  tags {
+    Name = "EKS Example Private Subnet"
+  }
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 resource "aws_subnet" "private2" {
   cidr_block        = "10.0.0.0/24"
   vpc_id            = aws_vpc.test_vpc.id
   availability_zone = "ap-southeast-2b"
+
+  tags {
+    Name = "EKS Example Private Subnet"
+  }
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 resource "aws_subnet" "private3" {
   cidr_block        = "10.0.1.0/24"
   vpc_id            = aws_vpc.test_vpc.id
   availability_zone = "ap-southeast-2c"
+
+  tags {
+    Name = "EKS Example Private Subnet"
+  }
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 resource "aws_subnet" "public1" {
   cidr_block        = "10.0.4.0/24"
   vpc_id            = aws_vpc.test_vpc.id
   availability_zone = "ap-southeast-2c"
+
+  tags {
+    Name = "EKS Example Public Subnet"
+  }
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 resource "aws_subnet" "public2" {
   cidr_block        = "10.0.5.0/24"
   vpc_id            = aws_vpc.test_vpc.id
   availability_zone = "ap-southeast-2b"
+
+  tags {
+    Name = "EKS Example Public Subnet"
+  }
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 resource "aws_subnet" "public3" {
   cidr_block        = "10.0.6.0/24"
   vpc_id            = aws_vpc.test_vpc.id
   availability_zone = "ap-southeast-2a"
+
+  tags {
+    Name = "EKS Example Public Subnet"
+  }
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+resource "aws_eip" "nat" {
+  vpc = true
 }
 
 resource "aws_internet_gateway" "gateway" {
   vpc_id = aws_vpc.test_vpc.id
+}
+
+resource "aws_nat_gateway" "this" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public1.id
+
+  depends_on = [aws_internet_gateway.gateway]
 }
 
 resource "aws_route_table" "public-router" {
@@ -56,3 +123,45 @@ resource "aws_route_table" "public-router" {
   }
 }
 
+resource "aws_route_table" "private-router" {
+  vpc_id = aws_vpc.test_vpc.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.this.id
+  }
+
+  tags {
+    Name = "Private Subnet"
+  }
+}
+
+resource "aws_route_table_association" "public1" {
+  subnet_id      = aws_subnet.public1.id
+  route_table_id = aws_route_table.public-router.id
+}
+
+resource "aws_route_table_association" "public2" {
+  subnet_id      = aws_subnet.public2.id
+  route_table_id = aws_route_table.public-router.id
+}
+
+resource "aws_route_table_association" "public3" {
+  subnet_id      = aws_subnet.public3.id
+  route_table_id = aws_route_table.public-router.id
+}
+
+resource "aws_route_table_association" "private1" {
+  subnet_id      = aws_subnet.private1.id
+  route_table_id = aws_route_table.private-router.id
+}
+
+resource "aws_route_table_association" "private2" {
+  subnet_id      = aws_subnet.private2.id
+  route_table_id = aws_route_table.private-router.id
+}
+
+resource "aws_route_table_association" "private3" {
+  subnet_id      = aws_subnet.private3.id
+  route_table_id = aws_route_table.private-router.id
+}

--- a/examples/default/network.tf
+++ b/examples/default/network.tf
@@ -2,7 +2,7 @@
 resource "aws_vpc" "test_vpc" {
   cidr_block = "10.0.0.0/16"
 
-  tags {
+  tags = {
     Name = "EKS Example VPC"
   }
 
@@ -16,7 +16,7 @@ resource "aws_subnet" "private1" {
   vpc_id            = aws_vpc.test_vpc.id
   availability_zone = "ap-southeast-2a"
 
-  tags {
+  tags = {
     Name = "EKS Example Private Subnet"
   }
 
@@ -30,7 +30,7 @@ resource "aws_subnet" "private2" {
   vpc_id            = aws_vpc.test_vpc.id
   availability_zone = "ap-southeast-2b"
 
-  tags {
+  tags = {
     Name = "EKS Example Private Subnet"
   }
 
@@ -44,7 +44,7 @@ resource "aws_subnet" "private3" {
   vpc_id            = aws_vpc.test_vpc.id
   availability_zone = "ap-southeast-2c"
 
-  tags {
+  tags = {
     Name = "EKS Example Private Subnet"
   }
 
@@ -58,7 +58,7 @@ resource "aws_subnet" "public1" {
   vpc_id            = aws_vpc.test_vpc.id
   availability_zone = "ap-southeast-2c"
 
-  tags {
+  tags = {
     Name = "EKS Example Public Subnet"
   }
 
@@ -72,7 +72,7 @@ resource "aws_subnet" "public2" {
   vpc_id            = aws_vpc.test_vpc.id
   availability_zone = "ap-southeast-2b"
 
-  tags {
+  tags = {
     Name = "EKS Example Public Subnet"
   }
 
@@ -86,7 +86,7 @@ resource "aws_subnet" "public3" {
   vpc_id            = aws_vpc.test_vpc.id
   availability_zone = "ap-southeast-2a"
 
-  tags {
+  tags = {
     Name = "EKS Example Public Subnet"
   }
 
@@ -131,7 +131,7 @@ resource "aws_route_table" "private-router" {
     nat_gateway_id = aws_nat_gateway.this.id
   }
 
-  tags {
+  tags = {
     Name = "Private Subnet"
   }
 }

--- a/examples/default/outputs.tf
+++ b/examples/default/outputs.tf
@@ -2,6 +2,11 @@ output "cluster_endpoint" {
   value = module.example.cluster_endpoint
 }
 
+output "cluster_config" {
+  value     = module.example.cluster_config
+  sensitive = true
+}
+
 output "platform_version" {
   value = module.example.platform_version
 }

--- a/kubernetes.tf
+++ b/kubernetes.tf
@@ -1,5 +1,4 @@
 provider "kubernetes" {
-  version                = "~>1.8"
   host                   = aws_eks_cluster.this.endpoint
   cluster_ca_certificate = base64decode(aws_eks_cluster.this.certificate_authority[0].data)
   token                  = data.aws_eks_cluster_auth.this.token

--- a/locals.tf
+++ b/locals.tf
@@ -29,15 +29,9 @@ users:
         - "${var.cluster_name}"
 KUBECONFIG
 
+  cluster_log_group = "${format("/aws/eks/%s/cluster", var.cluster_name)}"
 
-  ##
-  # Worker node user data payload
-  ##
-  worker_node_userdata = <<USERDATA
-#!/bin/bash
-set -o xtrace
-/etc/eks/bootstrap.sh --apiserver-endpoint '${aws_eks_cluster.this.endpoint}' --b64-cluster-ca '${aws_eks_cluster.this.certificate_authority[0].data}' '${var.cluster_name}'
-USERDATA
+  worker_node_log_group = "${format("/aws/eks/%s/node_logs",var.cluster_name)}"
 
 }
 

--- a/locals.tf
+++ b/locals.tf
@@ -31,7 +31,7 @@ KUBECONFIG
 
   cluster_log_group = "${format("/aws/eks/%s/cluster", var.cluster_name)}"
 
-  worker_node_log_group = "${format("/aws/eks/%s/node_logs",var.cluster_name)}"
+  worker_node_log_group = "${format("/aws/eks/%s/node_logs", var.cluster_name)}"
 
 }
 

--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,8 @@ resource "aws_launch_configuration" "worker_node" {
   instance_type        = var.worker_node_instance_type
   name_prefix          = var.cluster_name
   security_groups      = [aws_security_group.worker_node.id]
-  user_data_base64     = base64encode(local.worker_node_userdata)
+  user_data            = data.template_file.user_data.rendered
+  key_name             = var.ssh_key_name
 
   lifecycle {
     create_before_destroy = true

--- a/outputs.tf
+++ b/outputs.tf
@@ -21,5 +21,6 @@ output "version" {
 output "cluster_config" {
   description = "Kube config file of the current cluster"
   value       = local.kubeconfig
+  sensitive   = true
 }
 

--- a/template.tf
+++ b/template.tf
@@ -1,0 +1,14 @@
+provider template {
+  version = "~> 2.1.2"
+}
+
+data "template_file" "user_data" {
+  template = "${file("${path.module}/templates/user_data.sh.tpl")}"
+
+  vars = {
+    log_group_name             = local.worker_node_log_group
+    eks_cluster_endpoint       = aws_eks_cluster.this.endpoint
+    eks_cluster_cert_auth_data = aws_eks_cluster.this.certificate_authority.0.data
+    eks_cluster_name           = var.cluster_name
+  }
+}

--- a/templates/user_data.sh.tpl
+++ b/templates/user_data.sh.tpl
@@ -1,0 +1,101 @@
+#!/bin/sh
+set -o xtrace
+echo "====== Configuring SSM..."
+
+sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+sudo systemctl status amazon-ssm-agent
+
+echo "====== Configuring the Cloudwatch Agent..."
+
+wget https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm
+sudo rpm -U ./amazon-cloudwatch-agent.rpm
+
+sudo cat <<-EOF > /opt/aws/amazon-cloudwatch-agent/bin/config.json
+{
+    "agent": {
+        "metrics_collection_interval": 30,
+        "run_as_user": "cwagent"
+    },
+    "logs": {
+        "logs_collected": {
+            "files": {
+                "collect_list": [
+                    {
+                        "file_path": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log",
+                        "log_group_name": "${log_group_name}",
+                        "log_stream_name": "cloudwatch-agent-{instance_id}"
+                    },
+                    {
+                        "file_path": "/var/log/messages",
+                        "log_group_name": "${log_group_name}",
+                        "log_stream_name": "syslog-{instance_id}"
+                    },
+                    {
+                        "file_path": "/var/log/cloud-init-output.log",
+                        "log_group_name": "${log_group_name}",
+                        "log_stream_name": "cloud-init-output-{instance_id}"
+                    }
+                ]
+            }
+        }
+    },
+    "metrics": {
+        "append_dimensions": {
+            "ImageID":"\$${aws:ImageId}",
+            "InstanceId":"\$${aws:InstanceId}",
+            "InstanceType":"\$${aws:InstanceType}",
+            "AutoScalingGroupName":"\$${aws:AutoScalingGroupName}"
+        },
+        "metrics_collected": {
+            "cpu": {
+                "measurement": [
+                    "cpu_usage_idle",
+                    "cpu_usage_iowait",
+                    "cpu_usage_user",
+                    "cpu_usage_system"
+                ],
+                "metrics_collection_interval": 30,
+                "totalcpu": false
+            },
+            "disk": {
+                "measurement": [
+                    "used_percent",
+                    "inodes_free"
+                ],
+                "metrics_collection_interval": 30,
+                "resources": [
+                    "*"
+                ]
+            },
+            "diskio": {
+                "measurement": [
+                    "io_time"
+                ],
+                "metrics_collection_interval": 30,
+                "resources": [
+                    "*"
+                ]
+            },
+            "mem": {
+                "measurement": [
+                    "mem_used_percent"
+                ],
+                "metrics_collection_interval": 30
+            },
+            "swap": {
+                "measurement": [
+                    "swap_used_percent"
+                ],
+                "metrics_collection_interval": 30
+            }
+        }
+    }
+}
+EOF
+
+#Give cwagent access to syslog
+sudo setfacl -m u:cwagent:r /var/log/messages
+
+sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/bin/config.json -s
+
+/etc/eks/bootstrap.sh --apiserver-endpoint ${eks_cluster_endpoint} --b64-cluster-ca ${eks_cluster_cert_auth_data} ${eks_cluster_name}

--- a/vars.tf
+++ b/vars.tf
@@ -61,3 +61,12 @@ variable "supports_kube2iam" {
   default     = false
 }
 
+variable "ssh_key_name" {
+  description = "The key pair to use for ssh connections"
+  default     = ""
+}
+
+variable "cloudwatch_log_retention" {
+  description = "The retention period in days for all CloudWatch Log Group. Defaults to `7 days`"
+  default     = 7
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,10 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "> 0.12.0, < 0.13.0"
   required_providers {
-    aws = "~> 2.19"
+    aws        = "~> 2.19"
+    kubernetes = "1.10"
+    template   = "~> 2.1.2"
+
   }
 }


### PR DESCRIPTION
Adds support for SSM Session Manager connections which allows a session connection without the need for a bastion host or sharing ssh keys.

Also adds EKS node worker log shipping of the

CloudWatch Agent log
Cloud-Init-Output log
Syslog (/var/log/messages)